### PR TITLE
Added install requirements to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,4 +8,7 @@ setup(name='tinker',
       author_email='brian.hutchinson@wwu.edu',
       license='MIT',
       packages=['tinker'],
+      install_requires=[
+          'requests',
+      ],
       zip_safe=False)


### PR DESCRIPTION
Issue arose when pip installing tinker in which we couldn't import it in python because the `requests` package dependency was not satisfied. This change fixes it and pip will automatically fulfill our dependencies if they don't exist.

TEST PLAN:
```
(tinker_pip_test_venv) cf408-hut-05 .../workspace/shelbom $ pip install git+https://github.com/hutchresearch/tinker.git@pip_setup
Collecting git+https://github.com/hutchresearch/tinker.git@pip_setup
  Cloning https://github.com/hutchresearch/tinker.git (to pip_setup) to /tmp/pip-tb6arx9t-build
Username for 'https://github.com': shelbom
Password for 'https://shelbom@github.com': 
Collecting requests (from tinker==0.1)
  Downloading requests-2.18.4-py2.py3-none-any.whl (88kB)
    100% |████████████████████████████████| 92kB 2.4MB/s 
Collecting idna<2.7,>=2.5 (from requests->tinker==0.1)
  Downloading idna-2.6-py2.py3-none-any.whl (56kB)
    100% |████████████████████████████████| 61kB 3.1MB/s 
Collecting certifi>=2017.4.17 (from requests->tinker==0.1)
  Downloading certifi-2017.7.27.1-py2.py3-none-any.whl (349kB)
    100% |████████████████████████████████| 358kB 1.9MB/s 
Collecting chardet<3.1.0,>=3.0.2 (from requests->tinker==0.1)
  Downloading chardet-3.0.4-py2.py3-none-any.whl (133kB)
    100% |████████████████████████████████| 143kB 2.5MB/s 
Collecting urllib3<1.23,>=1.21.1 (from requests->tinker==0.1)
  Downloading urllib3-1.22-py2.py3-none-any.whl (132kB)
    100% |████████████████████████████████| 133kB 4.9MB/s 
Installing collected packages: idna, certifi, chardet, urllib3, requests, tinker
  Running setup.py install for tinker ... done
Successfully installed certifi-2017.7.27.1 chardet-3.0.4 idna-2.6 requests-2.18.4 tinker-0.1 urllib3-1.22
(tinker_pip_test_venv) cf408-hut-05 .../workspace/shelbom $ python
Python 3.5.2 (default, Sep 14 2017, 22:51:06) 
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import tinker
>>> 
```
Observe that importing tinker raises no errors.