### PR TITLE
changed ip reference to url of server.

### DIFF
--- a/wwu_tinker/__init__.py
+++ b/wwu_tinker/__init__.py
@@ -2,4 +2,4 @@ import json
 import requests
 import traceback
 
-server = "http://140.160.142.44:6060/"
+server = "http://ml-tuning.proj.cs.wwu.edu:6060/"


### PR DESCRIPTION
We were referring to the IP address of our server, rather than the actual url. Because the IP may change, we need to use the URL in all places that we find the IP.